### PR TITLE
Cache external URI calls

### DIFF
--- a/octohatrack/__init__.py
+++ b/octohatrack/__init__.py
@@ -22,8 +22,6 @@ def main():
       sys.exit(1)
 
     code_contributors = get_code_contributors(repo_name)
-    
-    progress("Collecting commentors")
     code_commentors = get_code_commentors(repo_name, args.limit)
   except ValueError as e:
     print(e)

--- a/octohatrack/__init__.py
+++ b/octohatrack/__init__.py
@@ -22,6 +22,8 @@ def main():
       sys.exit(1)
 
     code_contributors = get_code_contributors(repo_name)
+    
+    progress("Collecting commentors")
     code_commentors = get_code_commentors(repo_name, args.limit)
   except ValueError as e:
     print(e)
@@ -36,7 +38,7 @@ def main():
   code_contributors = sorted(code_contributors, key=lambda k: k['user_name'].lower()) 
   non_code_contributors = sorted(non_code_contributors, key=lambda k: k['user_name'].lower()) 
 
-  print("\nCode contributions: %d" % len(code_contributors))
+  print("\n\nCode contributions: %d" % len(code_contributors))
 
   if args.show_contributors:
     for user in code_contributors: 

--- a/octohatrack/__init__.py
+++ b/octohatrack/__init__.py
@@ -36,7 +36,7 @@ def main():
   code_contributors = sorted(code_contributors, key=lambda k: k['user_name'].lower()) 
   non_code_contributors = sorted(non_code_contributors, key=lambda k: k['user_name'].lower()) 
 
-  print("\n\nCode contributions: %d" % len(code_contributors))
+  print("\nCode contributions: %d" % len(code_contributors))
 
   if args.show_contributors:
     for user in code_contributors: 

--- a/octohatrack/helpers.py
+++ b/octohatrack/helpers.py
@@ -136,6 +136,7 @@ def get_user(uri):
     if entry is not None:
         return get_user_data(entry)
 
+@memoise
 def repo_exists(repo_name):
     try:
         repo = conn.send("GET", "/repos/%s" % repo_name)

--- a/octohatrack/helpers.py
+++ b/octohatrack/helpers.py
@@ -9,12 +9,14 @@ from functools import wraps
 
 # Always run on start import
 cache_file = "cache_file.json"
+cache = {}
 
 if os.path.isfile(cache_file):
     with open(cache_file, "r") as f:
-        cache = json.load(f) 
-else:
-    cache = {}
+        try: 
+            cache = json.load(f) 
+        except ValueError:
+            pass 
 
 # Always run on exit
 def save_cache():

--- a/octohatrack/helpers.py
+++ b/octohatrack/helpers.py
@@ -87,7 +87,6 @@ def get_code_commentors(repo_name, limit):
 
   users = []
   for index in range(minimum, pri_count + 1):
-      progress_advance()
       users.append(get_user("/repos/%s/pulls/%d" % (repo_name, index)))
       users.append(get_user("/repos/%s/issues/%d" % (repo_name, index)))
 

--- a/octohatrack/helpers.py
+++ b/octohatrack/helpers.py
@@ -90,10 +90,12 @@ def get_code_commentors(repo_name, limit):
       users.append(get_user("/repos/%s/pulls/%d" % (repo_name, index)))
       users.append(get_user("/repos/%s/issues/%d" % (repo_name, index)))
 
-      json = get_paged_json("/repos/%s/pulls/%d/comments" % (repo_name, index))
-      json += get_paged_json("/repos/%s/issues/%d/comments" % (repo_name, index))
-      for entry in json:
+      for entry in get_paged_json("/repos/%s/pulls/%d/comments" % (repo_name, index)):
             users.append(get_user_data(entry))
+
+      for entry in get_paged_json("/repos/%s/issues/%d/comments" % (repo_name, index)):
+            users.append(get_user_data(entry))
+
   progress_complete()
 
   return unique(users)


### PR DESCRIPTION
I've rearranged the external calls, including the pagination calls, so that I can memoise via a unique url the JSON response of the API calls. 

The cache dict is stored as a local JSON file so it can be recalled on subsequent runs of the script. 

Additionally, this captures all external calls, so re-runs of the script do not call externally (testable by disabling local network after a full successful run and re-running)

Thanks to @aurynn, @tveastman and @ncoghlan for the tips to get this happening :)