### PR TITLE
Major cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,33 @@
 ![PyPI](https://img.shields.io/pypi/l/octohatrack.svg)
 ![PyPI](https://img.shields.io/pypi/implementation/octohatrack.svg)
 
-It's easy to see your direct [code contributions](https://help.github.com/articles/why-are-my-contributions-not-showing-up-on-my-profile/)
-on GitHub, but what about everything else?
+It's easy to see some [code contributions](https://help.github.com/articles/why-are-my-contributions-not-showing-up-on-my-profile/)
+on a GitHub repo, but what about everything else?
 
-**Octohatrack** takes a github repo name, and returns a list of every
-github user that has interacted with a project, but has not committed
-code.
+**Octohatrack** takes a github repo name, and returns two lists: 
+    - A list of all users as defined by GitHub as a contributor
+    - A list of all contributors to a project 
 
-Interactions include:
+**What is a 'GitHub contributor'?**
 
--   raising or commenting on an issue
--   raising or commenting on a pull request
--   commenting on a commit
+On any GitHub repo page, the header at the top of the file listings shows a number of commits, branches, releases and contributors. If you [click the 'contributors' link](https://github.com/LABHR/octohatrack/graphs/contributors), you get a list of users that contributed code to the master branch of the repo, ordered by the commits and lines of code contributed. This list is limited to the top 100 users
+
+**So, what are 'all contributors', then?**
+
+That's everyone who's worked on a GitHub project. It compiles a complete list of the GitHub-defined contributors (not just the top 100), plus everyone who's created an issue, opened a pull requests, commented on an issue, replied to a pull request, made any in-line comments on code, edited the repo wiki, or in any other way interacted with the repo. 
+
+**Limitations**
+
+As at April 2016, there is no API endpoint for reactions, so these aren't able to be counted. 
+
+**#LABHR**
 
 "Let's All Build a Hat Rack" ([\#LABHR](https://twitter.com/search?q=%23LABHR&src=typd)) is an
 original concept by [Leslie Hawthorn](http://hawthornlandings.org/2015/02/13/a-place-to-hang-your-hat/)
 
 Read more about octohatrack:
 
--   [A tool for tracking non-code GitHub contributions](https://opensource.com/life/15/10/octohatrack-github-non-code-contribution-tracker) on OpenSource.com
+-   [A tool for tracking GitHub contributions](https://opensource.com/life/15/10/octohatrack-github-non-code-contribution-tracker) on OpenSource.com
 -   [Acknowledging Non-Coding Contributions](https://modelviewculture.com/pieces/acknowledging-non-coding-contributions) on ModelViewCulture.com
 -   [Build a Better Hat Rack: All Contributions Welcome](https://www.youtube.com/watch?v=wQxFKxbWcFM) from KiwiPyCon (YouTube video)
 -   [Read about the project name change](http://glasnt.com/blog/2015/11/21/goodbye-octohat.html)
@@ -38,18 +46,16 @@ pip install octohatrack
 ## Usage
 
 ```
-$ octohatrack --help
-usage: octohatrack.py [-h] [-l LIMIT] [--no-cache] [-v] repo_name
+usage: octohatrack [-h] [--no-cache] [-v] [-l 10] username/repo
 
 positional arguments:
-  repo_name             githubuser/repo
+  username/repo      the name of the repo to parse
 
 optional arguments:
-  -h, --help            show this help message and exit
-  -l LIMIT, --limit LIMIT
-                        Limit to the last x Issues/Pull Requests
-  --no-cache            Disable local caching of API results
-  -v, --version         show program's version number and exit
+  -h, --help         show this help message and exit
+  --no-cache         Disable local caching of API results
+  -v, --version      show program's version number and exit
+  -l 10, --limit 10  Limit to the last x Issues/Pull Requests
 ```
 
 Define an environment variable for `GITHUB_TOKEN` to use an [authentication token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) to avoide being [Rate Limited](https://developer.github.com/v3/#rate-limiting)
@@ -76,10 +82,10 @@ docker run -e GITHUB_TOKEN octohatrack [arguments]
 ## Example output
 
 ```
-Collecting contributors...
-Collecting commentors............................................................................................................................................................................................
+Collecting API contributors...
+Collecting all repo contributors...
 
-Code contributors: 10
+GitHub Contributors:
 alicetragedy (Laura)
 davidjb (David Beitey)
 glasnt (Katie McLaughlin)
@@ -91,18 +97,34 @@ tacaswell (Thomas A Caswell)
 tclark (Tom Clark)
 timgws (Tim Groeneveld)
 
-Non-coding contributors: 11
+All Contributors:
+alicetragedy (Laura)
 brainwane (Sumana Harihareswara)
+davidjb (David Beitey)
 dshafik (Davey Shafik)
 edunham (E. Dunham)
 freakboy3742 (Russell Keith-Magee)
 gitter-badger (The Gitter Badger)
+glasnt (Katie McLaughlin)
 jniggemann (Jan)
 Ketsuban (Thomas Winwood)
 KirstieJane (Kirstie Whitaker)
+kristianperkins (Kristian Perkins)
 leesdolphin (Lee Symes)
+Lukasa (Cory Benfield)
+mfs (Mike Sampson)
+mjtamlyn (Marc Tamlyn)
 ncoghlan
+ossanna16 (Anna Ossowski)
 stewart-ibm (Stewart Smith)
+SvenDowideit (Sven Dowideit)
+tacaswell (Thomas A Caswell)
+tclark (Tom Clark)
+timgws (Tim Groeneveld)
+
+Repo: LABHR/octohatrack
+GitHub Contributors: 10
+All Contributors: 23
 ```
 
 
@@ -121,11 +143,16 @@ To reset the cache, remove the `cache_file.json` file.
 If you experience ongoing issues with the caching,
 please [log a detailed issue describing what you're seeing](https://github.com/LABHR/octohatrack/issues/new)
 
+### Wiki
+
+Because GitHub doesn't have an API endpoint for being able to parse gollum-based repo-wikis, I've had to default to cloning repos locally and parsing via gitpython. 
+
+If there are issues cloning the wiki, or other issues, it shouldn't break an octohatrack run, but if you do encounter issues, please [log an issue](https://github.com/LABHR/octohatrack/issues/new), and be sure to include platform information (this functionality has been tested on Mac OSX Yosemite and Ubuntu Xeniel)
+
 
 ## To do
 
--   include merge-only contributors as non-code contributors
--   verify correct statistics from repos with multi-person Pull Requests (#65)
+-   include merge-only contributors
 
 ## Code of Conduct
 

--- a/octohatrack/__init__.py
+++ b/octohatrack/__init__.py
@@ -1,37 +1,30 @@
 #!/usr/bin/env python
 
 import argparse
+from argparse import SUPPRESS
 import sys
 import pkg_resources
-from .helpers import (repo_exists, get_code_commentors,
-                      get_code_contributors, consolidate, display_users)
+from .helpers import (repo_exists, get_api_contributors, get_pri_contributors, unique_users, display_results)
 from .wiki import (get_wiki_contributors)
 
 def main():
   version = pkg_resources.require("octohatrack")[0].version
 
   parser = argparse.ArgumentParser()
-  parser.add_argument("repo_name", help="githubuser/repo")
-  parser.add_argument("-l", "--limit",
-                      help="Limit to the last x Issues/Pull Requests",
-                      type=int, default=0)
-  parser.add_argument("--no-cache", action='store_false',
-                      help='Disable local caching of API results')
-  parser.add_argument("-w", "--wiki", action='store_true',
-                      help="Experimental: Show wiki contributions, if available")
-  parser.add_argument("-v", "--version", action='version',
-                      version="octohatrack version %s" % version)
+  parser.add_argument("repo_name", metavar="username/repo", help="the name of the repo to parse")
+  parser.add_argument("--no-cache", action='store_false', help='Disable local caching of API results')
+  parser.add_argument("-v", "--version", action='version', version="octohatrack version %s" % version)
+  parser.add_argument("-l", "--limit", metavar=10, help="Limit to the last x Issues/Pull Requests", type=int, default=0)
 
-  # Deprecated
-  parser.add_argument("-c", "--show-contributors", action='store_true',
-                      help="DEPRECATED - Output the code contributors")
-  parser.add_argument("-n", "--show-names", action='store_true',
-                      help="DEPRECATED - Show the user's display name")
-  parser.add_argument("-g", "--generate-html", action='store_true',
-                      help="DEPRECATED - Generate output as HTML")
+  # Deprecated flags
+  parser.add_argument("-c", "--show-contributors", action="store_true", help=SUPPRESS)
+  parser.add_argument("-n", "--show-names", action="store_true", help=SUPPRESS)
+  parser.add_argument("-g", "--generate-html", action="store_true", help=SUPPRESS)
+  parser.add_argument("-w", "--wiki", action="store_true", help=SUPPRESS)
 
   args = parser.parse_args()
 
+  # Deprecation warnings
   if args.show_contributors:
     print("The --show-contributors (-c) flag is deprecated. Ignoring.")
 
@@ -40,6 +33,9 @@ def main():
   
   if args.generate_html:
     print("The --generate-html (-g) flag is deprecated. Ignoring.")
+
+  if args.wiki:
+    print("The --wiki (-w) flag is deprecated. Ignoring.")
   
   repo_name = args.repo_name
 
@@ -48,22 +44,16 @@ def main():
       print("Repo does not exist: %s" % repo_name)
       sys.exit(1)
 
-    code_contributors = get_code_contributors(repo_name)
-    code_commentors = get_code_commentors(repo_name, args.limit)
+    api_contributors = get_api_contributors(repo_name)
+    pri_contributors = get_pri_contributors(repo_name, args.limit)
+    wiki_contributors = get_wiki_contributors(repo_name)
   except ValueError as e:
     print(e)
     sys.exit(1)
 
-  non_code_contributors = consolidate(code_contributors, code_commentors)
+  all_contributors = unique_users(api_contributors, pri_contributors, wiki_contributors)
 
-  if args.wiki:
-    wiki_contributors = get_wiki_contributors(repo_name, code_contributors, non_code_contributors)
-
-  display_users(code_contributors, "Code contributors")
-  display_users(non_code_contributors, "Non-coding contributors")
-
-  if args.wiki:
-    display_users(wiki_contributors, "Wiki contributors")
+  display_results(repo_name, api_contributors, all_contributors)
 
 if __name__ == "__main__":
   main()

--- a/octohatrack/wiki.py
+++ b/octohatrack/wiki.py
@@ -25,9 +25,8 @@ from .helpers import (progress, progress_advance, get_user_data)
 tmp_folder = "tmprepo"
 
 
-def get_wiki_contributors(repo_name, code, non_code):
+def get_wiki_contributors(repo_name):
 
-    progress("Collecting wiki contributors")
 
     wiki_url = "https://github.com/%s.wiki" % repo_name
 
@@ -41,9 +40,10 @@ def get_wiki_contributors(repo_name, code, non_code):
     # as a replacement for an API check
     resp = requests.get("https://github.com/%s/wiki" % repo_name)
     if "Clone this wiki locally" not in resp.text:
-        print("No wiki")
         return []
     
+    progress("Collecting wiki contributors")
+
     progress_advance()
 
     # Attempt to clone the repo, catching all gitpython ValueError errors
@@ -65,29 +65,13 @@ def get_wiki_contributors(repo_name, code, non_code):
         wiki_contributors.append(i.author)
 
     # Return a unique set of contributors
-    wiki = list(set(wiki_contributors))
+    response = list(set(wiki_contributors))
 
-    if len(wiki) == 0:
-        print("\nWiki contributors: 0 (no wiki)")
-        return
+    users = []
 
-    github_users=[]
+    for entry in response:
+        user = get_user_data({"login": str(entry), "avatar_url": ""})
+        if user is not None:
+            wiki.append(user)
 
-    for x in code: 
-        github_users.append(x['name'])
-    for x in non_code:
-        github_users.append(x['name'])
-
-    new_wiki = []
-
-    # Ignore any users who's author names match an existing listing 
-    # as a code or non-coding contribution
-    #
-    # WARNING: Possibly a lossy process
-    for user in wiki: 
-        u = str(user)
-        if u in github_users:
-            continue
-        new_wiki.append(get_user_data({"login": u, "avatar_url": ""}))
-
-    return new_wiki
+    return users

--- a/octohatrack/wiki.py
+++ b/octohatrack/wiki.py
@@ -72,6 +72,6 @@ def get_wiki_contributors(repo_name):
     for entry in response:
         user = get_user_data({"login": str(entry), "avatar_url": ""})
         if user is not None:
-            wiki.append(user)
+            users.append(user)
 
     return users

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
 
 setup(
     name='octohatrack',
-    version='0.4.0',
+    version='0.4.1',
     description='Non-code contribution groker for GitHub',
     long_description=long_description,
     url='https://github.com/labhr/octohatrack',
@@ -20,7 +20,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
     ],
-    keywords='octohatrack github contributions non-code',
+    keywords='octohatrack github contributions',
     install_requires=['requests', 'simplejson', 'gitpython'],
     entry_points={
       'console_scripts': [ "octohatrack = octohatrack:main" ]


### PR DESCRIPTION
 - rename categories to GitHub Contributors and All Contributors (concat GH contributors, previously 'non-coding')
 - cleanup general formatting of output, with summaries at the end
 - some helper code cleanup
 - use SUPPRESS for deprecated flags