### PR TITLE
An attempt at limiting installation to python3 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
   - "pip install ."
 script: 
   - "octohatrack LABHR/octohatrack"
-  - "python -m octohatrack programminghistorian/jekyll"
+  - "python -m octohatrack LABHR/octohatrack"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,12 @@
 from setuptools import setup, find_packages
 from codecs import open
 from os import path
+import sys
+
+# Exit unless we're in pip3/Python 3
+if not sys.version_info[0] == 3:
+    print("\noctohatrack requires a Python 3 environment.\n\nTry `pip3 install` instead")
+    sys.exit(1)
 
 here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:


### PR DESCRIPTION
I would love someone who knows more about setup.py etc to check this for me. 

I know that in systems with both Python 2.7 and Python 3 you can `pip` install to Python 2.7, or `pip3` install to Python 3. I'm assuming that if you install `octohatrack` under `pip3` the `which octohatrack` script will use Python 3.

This attempts to prevent installation via pip in a Python 2.7 environment. 

With thanks to tdsmith on freenode #pypa for the tip