### PR TITLE
use 100 results per page instead of default 30

### DIFF
--- a/octohatrack/connection.py
+++ b/octohatrack/connection.py
@@ -23,12 +23,15 @@ class Pager(object):
         self.uri = uri
         self.params = params
         self.max_pages = max_pages
+        self.per_page = 100
         self.count = 0
 
     def __iter__(self):
         while True:
             self.count += 1
-            response = self.conn.send('GET', self.uri, self.params)
+            params = self.params.copy()
+            params.setdefault('per_page', self.per_page)
+            response = self.conn.send('GET', self.uri, params)
             yield response
 
             if self.count == self.max_pages:

--- a/octohatrack/helpers.py
+++ b/octohatrack/helpers.py
@@ -83,7 +83,7 @@ def get_page_int_json(uri):
    page = 1
    while True:
       progress_advance()
-      response = get_data("%s?page=%d" % (uri, page))
+      response = get_data("%s?page=%d&per_page=100" % (uri, page))
       if len(response) == 0:
          break
       else:


### PR DESCRIPTION
- significantly decreases # of requests and speed
- if `per_page` is not supported by the endpoint, I believe it will simply be ignored
- to that end, I am pretty sure all of the endpoints in use here support `per_page`.

I tested this manually and see no difference in octohatrack's output.  But the pull went much faster, and I didn't exhaust my token request limit.