### PR TITLE
README.md: Revise limitation regarding reactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See the bottom of [CONTRIBUTORS](https://github.com/LABHR/octohatrack/blob/maste
 
 **Limitations**
 
-As at April 2016, there is no API endpoint for [GitHub Reactions](https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments), so these aren't able to be counted. [Issue #87](https://github.com/LABHR/octohatrack/issues/87)
+[GitHub Reactions](https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments) are not counted. [Issue #87](https://github.com/LABHR/octohatrack/issues/87)
  
 
 **#LABHR**


### PR DESCRIPTION
Reactions are now part of the API and GraphQL.
It has not been implemented yet.

Related to https://github.com/LABHR/octohatrack/issues/87